### PR TITLE
Add option to tag all cards that belong to a opening

### DIFF
--- a/src/config.md
+++ b/src/config.md
@@ -81,6 +81,10 @@ One of "black" or "white"
 
 This list of imported filenames.
 
+### `imports.ID.tag`
+
+An optional tag that is added to all notes in this opening.
+
 ## `notetype`
 
 The note type that you had selected. This should be a note type with

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -59,6 +59,10 @@
 							"items": {
 							"type": "string"
 							}
+						},
+						"tag": {
+							"type": "string",
+							"description": "Optional tag for notes in this opening"
 						}
 					},
 					"required": ["colour", "files"]

--- a/src/dialog.py
+++ b/src/dialog.py
@@ -18,7 +18,7 @@ from aqt.operations import QueryOp
 # pylint: disable=no-name-in-module
 from aqt.qt import (QComboBox, QDialog, # type: ignore[attr-defined]
                     QDialogButtonBox, QFileDialog, # type: ignore[attr-defined]
-                    QGridLayout, QLabel, # type: ignore[attr-defined]
+                    QGridLayout, QLabel, QLineEdit, # type: ignore[attr-defined]
                     QListWidget, QListWidgetItem, # type: ignore[attr-defined]
                     QPushButton, Qt, QMessageBox, # type: ignore[attr-defined]
                     QDesktopServices, QUrl, # type: ignore[attr-defined]
@@ -96,10 +96,14 @@ class ImportDialog(QDialog):
 		if current_index >= 0:
 			self.model_combo.setCurrentIndex(current_index)
 
+		layout.addWidget(QLabel(_('Tag')), 4, 0)
+		self.tag_edit = QLineEdit()
+		layout.addWidget(self.tag_edit, 4, 1)
+
 		btn = QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
 		self.button_box = QDialogButtonBox(btn)
 		layout.addWidget(self.button_box,
-		                 4,
+		                 5,
 		                 0,
 		                 1,
 		                 3,
@@ -142,6 +146,9 @@ class ImportDialog(QDialog):
 				record = config['imports'][str(deck_id)]
 				for filename in record['files']:
 					self.file_list.addItem(filename)
+				self.tag_edit.setText(record.get('tag', ''))
+			else:
+				self.tag_edit.clear()
 
 		self.updating = False
 
@@ -161,6 +168,9 @@ class ImportDialog(QDialog):
 
 			for filename in record['files']:
 				self.file_list.addItem(filename)
+			self.tag_edit.setText(record.get('tag', ''))
+		else:
+			self.tag_edit.clear()
 
 		self.updating = False
 
@@ -196,6 +206,9 @@ class ImportDialog(QDialog):
 				record = config['imports'][str(deck_id)]
 				for filename in record['files']:
 					self.file_list.addItem(filename)
+				self.tag_edit.setText(record.get('tag', ''))
+			else:
+				self.tag_edit.clear()
 
 		if config['notetype'] is not None:
 			notetype_id = config['notetype']
@@ -248,6 +261,7 @@ class ImportDialog(QDialog):
 				record = self.config['imports'][str(deck_id)]
 				filenames = record['files']
 				notetype_id = self.config['notetype']
+				tag = record.get('tag')
 
 				importer = Importer(
 					collection=mw.col,
@@ -255,6 +269,7 @@ class ImportDialog(QDialog):
 					notetype_id=notetype_id,
 					filenames=filenames,
 					colour=('white' == colour),
+					tag=tag,
 				)
 
 				return importer.run()
@@ -364,13 +379,19 @@ class ImportDialog(QDialog):
 			if item is not None:
 				files.append(item.text())
 
+		tag = self.tag_edit.text().strip()
+
 		self.config['colour'] = colour
 		self.config['decks'][colour] = deck_id
 
-		self.config['imports'][str(deck_id)] = {
+		import_record = {
 			'colour': colour,
 			'files': files,
 		}
+		if tag:
+			import_record['tag'] = tag
+
+		self.config['imports'][str(deck_id)] = import_record
 
 		self.config['notetype'] = notetype_id
 

--- a/src/dialog.py
+++ b/src/dialog.py
@@ -16,7 +16,7 @@ from typing import List, Literal, Union
 from aqt import mw, AnkiQt
 from aqt.operations import QueryOp
 # pylint: disable=no-name-in-module
-from aqt.qt import (QComboBox, QDialog, # type: ignore[attr-defined]
+from aqt.qt import (QComboBox, QCompleter, QDialog, # type: ignore[attr-defined]
                     QDialogButtonBox, QFileDialog, # type: ignore[attr-defined]
                     QGridLayout, QLabel, QLineEdit, # type: ignore[attr-defined]
                     QListWidget, QListWidgetItem, # type: ignore[attr-defined]
@@ -98,6 +98,12 @@ class ImportDialog(QDialog):
 
 		layout.addWidget(QLabel(_('Tag')), 4, 0)
 		self.tag_edit = QLineEdit()
+		if self.mw is not None and hasattr(self.mw, 'col') and self.mw.col is not None:
+			tags = sorted(self.mw.col.tags.all())
+			completer = QCompleter(tags, self)
+			completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+			completer.setFilterMode(Qt.MatchFlag.MatchContains)
+			self.tag_edit.setCompleter(completer)
 		layout.addWidget(self.tag_edit, 4, 1)
 
 		btn = QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel

--- a/src/importer.py
+++ b/src/importer.py
@@ -33,7 +33,8 @@ class Importer:
 	    collection: Collection,
 	    colour: chess.Color,
 	    notetype_id: NotetypeId,
-	    deck_id: DeckId
+	    deck_id: DeckId,
+	    tag: Optional[str] = None
 	) -> None:
 		self.collection = collection
 		self.colour = colour
@@ -50,6 +51,12 @@ class Importer:
 
 		self.visitor = PositionVisitor(colour=colour)
 		self.filenames = filenames
+		self.tags: List[str] = []
+		if tag:
+			if hasattr(self.collection, 'tags') and hasattr(self.collection.tags, 'split'):
+				self.tags = self.collection.tags.split(tag)
+			else:
+				self.tags = [t for t in tag.strip().split() if t]
 
 
 	def run(self) -> Tuple[int, int, int, int, int]:
@@ -104,7 +111,15 @@ class Importer:
 	def _update_note(self, note: Note, question: Question) -> bool:
 		rendered_question = question.render(note.id)
 		answer: Answer = cast(Answer, question.render_answers(note.id))
-		if not note.fields[0] == rendered_question or not note.fields[1] == answer:
+		fields_changed = not note.fields[0] == rendered_question or not note.fields[1] == answer
+
+		tags_changed = False
+		for t in self.tags:
+			if not note.has_tag(t):
+				note.add_tag(t)
+				tags_changed = True
+
+		if fields_changed or tags_changed:
 			note.fields[0] = rendered_question
 			note.fields[1] = answer
 			self.collection.update_note(note)
@@ -114,6 +129,9 @@ class Importer:
 
 	def _create_note(self, question: Question) -> Note:
 		note = Note(self.collection, self.model)
+		for t in self.tags:
+			if not note.has_tag(t):
+				note.add_tag(t)
 
 		# We have to add the note first without content so that we have a
 		# note id to work with.

--- a/src/schema.py
+++ b/src/schema.py
@@ -65,6 +65,11 @@ schema = {
 							'items': {
 								'type': 'string'
 							}
+						},
+						'tag': {
+							'type': 'string',
+							'description':
+							'Optional tag for notes in this opening'
 						}
 					},
 					'required': ['colour', 'files']

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -122,6 +122,35 @@ class TestUpdate(unittest.TestCase):
 		got = updater.update_config(matching_config)
 		self.assertDictEqual(wanted, got)
 
+	@patch('src.updater.basic_names', BASIC_NAMES)
+	@patch('anki.lang.current_lang', 'en-US')
+	def test_config_with_tag(self):
+		"""Tests that config with tag field in imports validates and is preserved."""
+		from jsonschema import validate
+		from src.schema import schema
+
+		version = sv.Version('1.2.3')
+		updater = Updater(version, self.mw_mock)
+
+		config = {
+			'version': str(version),
+			'colour': 'white',
+			'decks': {'white': WHITE_DECK_ID, 'black': None},
+			'imports': {
+				str(WHITE_DECK_ID): {
+					'colour': 'white',
+					'files': ['/path/to/italian.pgn'],
+					'tag': 'italian_game'
+				}
+			},
+			'notetype': MOCK_NOTETYPE_ID
+		}
+
+		# Verify it passes jsonschema validation
+		validate(config, schema=schema)
+
+		got = updater.update_config(config)
+		self.assertEqual(got['imports'][str(WHITE_DECK_ID)]['tag'], 'italian_game')
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
Adds an optional **Tag** input field to the PGN import dialog. When provided, the tag is applied to all notes for that opening (both newly inserted and preexisting notes in the deck) while preserving any existing tags.